### PR TITLE
Remove runtime targets when building SPIR-V/LLVM Translator

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -76,7 +76,9 @@ llvm-spirv)
 
     CMAKE_EXTRA_ARGS=-DLLVM_SPIRV_INCLUDE_TESTS=OFF
     LLVM_ENABLE_PROJECTS="llvm-spirv"
+    LLVM_ENABLE_RUNTIMES=
     NINJA_TARGET=install-llvm-spirv
+    NINJA_TARGET_RUNTIMES=
     ;;
 llvm-*)
     BASENAME=llvm


### PR DESCRIPTION
This PR stops the libcxx and libcxxabi runtimes from being built, since, as far as I can tell, they aren't 
necessary for the Translator. This should (hopefully) fix the problem raised in #25.