### PR TITLE
✨ Add the Dang compiler!

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -42,6 +42,11 @@ embed-trunk)
     URL=https://github.com/ThePhD/llvm-project.git
     VERSION=embed-trunk-$(date +%Y%m%d)
     ;;
+dang-main)
+    BRANCH=dang
+    URL=https://github.com/ThePhD/llvm-project.git
+    VERSION=dang-main-$(date +%Y%m%d)
+    ;;
 lifetime-trunk)
     BRANCH=lifetime
     URL=https://github.com/mgehre/llvm-project.git


### PR DESCRIPTION
This PR adds the Derpstorm Clang ("Dang") compiler. It's meant to supercede the std::embed compiler, and it also provides one target that will can be modified / upgraded without needing a new compiler-per-feature that comes out of me. (I have a feeling there'll be a LOT of C and C++ implementations that'll be coming from me....)

In conjunction with:
- https://github.com/compiler-explorer/infra/pull/666
- https://github.com/compiler-explorer/compiler-explorer/pull/3296