### PR TITLE
Add widberg compiler

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -52,6 +52,11 @@ dang-main)
     URL=https://github.com/ThePhD/llvm-project.git
     VERSION=dang-main-$(date +%Y%m%d)
     ;;
+widberg-main)
+    BRANCH=main
+    URL=https://github.com/widberg/llvm-project-widberg-extensions.git
+    VERSION=widberg-main-$(date +%Y%m%d)
+    ;;
 lifetime-trunk)
     BRANCH=lifetime
     URL=https://github.com/mgehre/llvm-project.git


### PR DESCRIPTION
This PR adds the [widberg clang compiler](https://github.com/widberg/llvm-project-widberg-extensions). This compiler is an experimental reverse engineering compiler being developed at the University of Massachusetts Lowell Computer Science Department. We believe that there will be great utility in being able to provide live links to code samples using the compiler in publications. The multi-repo organization of CE is somewhat unwieldy to an outsider like me, so I have undoubtably made a mistake in t least one of these PRs; thank you for any fixes you are able to provide.

Related PRs:
https://github.com/compiler-explorer/infra/pull/721
https://github.com/compiler-explorer/compiler-workflows/pull/8
https://github.com/compiler-explorer/compiler-explorer/pull/3658