### PR TITLE
Add ROCm compiler and device libraries

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -108,6 +108,29 @@ llvm-spirv)
     NINJA_TARGET=install-llvm-spirv
     NINJA_TARGET_RUNTIMES=
     ;;
+rocm-*)
+    BASENAME=llvm-amdgpu
+    TAG=${VERSION}
+    ROCM_DEVICE_LIBS_BRANCH=${VERSION}
+
+    URL=https://github.com/RadeonOpenCompute/llvm-project.git
+    ROCM_DEVICE_LIBS_URL=https://github.com/RadeonOpenCompute/ROCm-Device-Libs.git
+
+    LLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra;compiler-rt;device-libs"
+    CMAKE_EXTRA_ARGS+=("-DLLVM_TARGETS_TO_BUILD=AMDGPU;X86")
+    ;;
+amd-stg-open)
+    BASENAME=llvm-amdgpu
+    BRANCH=${VERSION}
+    ROCM_DEVICE_LIBS_BRANCH=${VERSION}
+    VERSION=trunk-$(date +%Y%m%d)
+
+    URL=https://github.com/RadeonOpenCompute/llvm-project.git
+    ROCM_DEVICE_LIBS_URL=https://github.com/RadeonOpenCompute/ROCm-Device-Libs.git
+
+    LLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra;compiler-rt;device-libs"
+    CMAKE_EXTRA_ARGS+=("-DLLVM_TARGETS_TO_BUILD=AMDGPU;X86")
+    ;;
 llvm-*)
     BASENAME=llvm
     NINJA_TARGET=install-llvm-headers
@@ -222,6 +245,11 @@ fi
 if [[ -n "${SPIRV_LLVM_TRANSLATOR_URL}" ]]; then
     # Checkout SPIR-V/LLVM Translator
     git clone --depth 1 --single-branch -b "${BRANCH}" "${SPIRV_LLVM_TRANSLATOR_URL}" "${ROOT}/llvm-project/llvm/projects/SPIRV-LLVM-Translator"
+fi
+
+if [[ -n "${ROCM_DEVICE_LIBS_URL}" ]]; then
+    # Checkout ROCm Device Libraries
+    git clone --depth 1 --single-branch -b "${ROCM_DEVICE_LIBS_BRANCH}" "${ROCM_DEVICE_LIBS_URL}" "${ROOT}/llvm-project/llvm/projects/Device-Libs"
 fi
 
 # Setup build directory and build configuration

--- a/build/build.sh
+++ b/build/build.sh
@@ -6,7 +6,7 @@ ROOT=$PWD
 VERSION=$1
 
 BINUTILS_GCC_VERSION=9.2.0
-CMAKE_EXTRA_ARGS=
+declare -a CMAKE_EXTRA_ARGS
 LLVM_ENABLE_PROJECTS="clang;"
 LLVM_ENABLE_RUNTIMES="libcxx;libcxxabi"
 LLVM_EXPERIMENTAL_TARGETS_TO_BUILD=
@@ -20,7 +20,7 @@ autonsdmi-trunk)
     BRANCH=experiments
     URL=https://github.com/cor3ntin/llvm-project.git
     VERSION=autonsdmi-trunk-$(date +%Y%m%d)
-    CMAKE_EXTRA_ARGS=-DLLVM_OPTIMIZED_TABLEGEN=ON
+    CMAKE_EXTRA_ARGS+=("-DLLVM_OPTIMIZED_TABLEGEN=ON")
     ;;
 cppx-trunk)
     BRANCH=compiler-explorer
@@ -77,7 +77,7 @@ llvmflang-trunk)
     LLVM_ENABLE_RUNTIMES=""
     NINJA_TARGET_RUNTIMES=
     # See https://github.com/compiler-explorer/clang-builder/issues/27
-    CMAKE_EXTRA_ARGS="-DCMAKE_CXX_STANDARD=17 -DLLVM_PARALLEL_COMPILE_JOBS=24"
+    CMAKE_EXTRA_ARGS+=("-DCMAKE_CXX_STANDARD=17" "-DLLVM_PARALLEL_COMPILE_JOBS=24")
     ;;
 relocatable-trunk)
     BRANCH=trivially-relocatable
@@ -102,7 +102,7 @@ llvm-spirv)
 
     SPIRV_LLVM_TRANSLATOR_URL=https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git
 
-    CMAKE_EXTRA_ARGS="-DLLVM_SPIRV_INCLUDE_TESTS=OFF -DSPIRV_SKIP_CLANG_BUILD=ON -DSPIRV_SKIP_DEBUG_INFO_TESTS=ON"
+    CMAKE_EXTRA_ARGS+=("-DLLVM_SPIRV_INCLUDE_TESTS=OFF" "-DSPIRV_SKIP_CLANG_BUILD=ON" "-DSPIRV_SKIP_DEBUG_INFO_TESTS=ON")
     LLVM_ENABLE_PROJECTS=""
     LLVM_ENABLE_RUNTIMES=
     NINJA_TARGET=install-llvm-spirv
@@ -146,7 +146,7 @@ mlir-*)
     assertions-trunk)
         BRANCH=main
         VERSION=assertions-trunk-$(date +%Y%m%d)
-        CMAKE_EXTRA_ARGS=-DLLVM_ENABLE_ASSERTIONS=ON
+        CMAKE_EXTRA_ARGS+=("-DLLVM_ENABLE_ASSERTIONS=ON")
         ;;
     *)
         TAG=llvmorg-${VERSION}
@@ -236,7 +236,7 @@ cmake \
     -DLLVM_BINUTILS_INCDIR:PATH="/opt/compiler-explorer/gcc-${BINUTILS_GCC_VERSION}/lib/gcc/x86_64-linux-gnu/${BINUTILS_GCC_VERSION}/plugin/include" \
     -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="${LLVM_EXPERIMENTAL_TARGETS_TO_BUILD}" \
     -DLLVM_PARALLEL_LINK_JOBS=4 \
-    ${CMAKE_EXTRA_ARGS}
+    "${CMAKE_EXTRA_ARGS[@]}"
 
 # Build and install artifacts
 ninja ${NINJA_TARGET}

--- a/build/build.sh
+++ b/build/build.sh
@@ -116,7 +116,7 @@ rocm-*)
     URL=https://github.com/RadeonOpenCompute/llvm-project.git
     ROCM_DEVICE_LIBS_URL=https://github.com/RadeonOpenCompute/ROCm-Device-Libs.git
 
-    LLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra;compiler-rt;device-libs"
+    LLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra;compiler-rt"
     CMAKE_EXTRA_ARGS+=("-DLLVM_TARGETS_TO_BUILD=AMDGPU;X86")
     ;;
 amd-stg-open)
@@ -128,7 +128,7 @@ amd-stg-open)
     URL=https://github.com/RadeonOpenCompute/llvm-project.git
     ROCM_DEVICE_LIBS_URL=https://github.com/RadeonOpenCompute/ROCm-Device-Libs.git
 
-    LLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra;compiler-rt;device-libs"
+    LLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra;compiler-rt"
     CMAKE_EXTRA_ARGS+=("-DLLVM_TARGETS_TO_BUILD=AMDGPU;X86")
     ;;
 llvm-*)


### PR DESCRIPTION
This adds the AMD fork of LLVM that is shipped with ROCm (a.k.a. llvm-amdgpu). Most of the changes made to llvm-amdgpu get upstreamed fairly quickly, so it's not really _that_ different from vanilla clang, but the ROCm releases don't correspond directly to LLVM releases and there are in fact some meaningful changes, so IMO it's worth including.

The llvm-amdgpu compiler is mainly used for C, C++ and HIP. The ROCm Device Libraries are needed for HIP code. They provide implementations of basic GPU functions that normally get inlined by the compiler.

~~It's been a long time since I last hacked on compiler-explorer, so I'll see if I can remember how to test this change...~~ Ah, yes. The README says exactly how.