### PR TITLE
Enable HLSL & experimental targets on clang trunk

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -132,6 +132,8 @@ llvm-*)
     if [[ "${VERSION}" == "trunk" ]]; then
         BRANCH=main
         VERSION=trunk-$(date +%Y%m%d)
+        CMAKE_EXTRA_ARGS+=("-DCLANG_ENABLE_HLSL=On")
+        LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="DirectX;SPIRV"
     else
         TAG=llvmorg-${VERSION}
     fi


### PR DESCRIPTION
Clang HLSL support requires a few additional files to be generated during the build, this generation is guarded by the `CLANG_ENABLE_HLSL` CMake option.

Additionally Clang's HLSL support is being implemented to support the DirectX target for DXIL generation. In the (hopefully) near future work on the SPIR-V codegenerator will also begin. Enabling both targets in compiler expolorer will allow developers working on the DirectX and SPIR-V support to use compiler explorer to compare code generation between Clang and DXC.