### PR TITLE
Apply our debug patch to clang trunk

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -165,24 +165,25 @@ mlir-*)
     trunk)
         BRANCH=main
         VERSION=trunk-$(date +%Y%m%d)
-        PATCH_TO_APPLY=./patches/ce-debug-clang-trunk.patch
+        PATCH_TO_APPLY="${ROOT}/patches/ce-debug-clang-trunk.patch"
         ;;
     assertions-trunk)
         BRANCH=main
         VERSION=assertions-trunk-$(date +%Y%m%d)
         CMAKE_EXTRA_ARGS+=("-DLLVM_ENABLE_ASSERTIONS=ON")
+        PATCH_TO_APPLY="${ROOT}/patches/ce-debug-clang-trunk.patch"
         ;;
     *)
         TAG=llvmorg-${VERSION}
         case $VERSION in
         "12.0.1" | "12.0.0")
-            PATCH_TO_APPLY=./patches/ce-debug-clang-12.patch
+            PATCH_TO_APPLY="${ROOT}/patches/ce-debug-clang-12.patch"
             ;;
         "11.0.1" | "11.0.0" | "10.0.1" | "10.0.0")
-            PATCH_TO_APPLY=./patches/ce-debug-clang-11.patch
+            PATCH_TO_APPLY="${ROOT}/patches/ce-debug-clang-11.patch"
             ;;
         *)
-            PATCH_TO_APPLY=./patches/ce-debug-clang-trunk.patch
+            PATCH_TO_APPLY="${ROOT}/patches/ce-debug-clang-trunk.patch"
             ;;
         esac
         ;;
@@ -245,7 +246,9 @@ mkdir -p "${STAGING_DIR}"
 git clone --depth 1 --single-branch -b "${BRANCH}" "${URL}" "${ROOT}/llvm-project"
 
 if [[ -n "${PATCH_TO_APPLY}" ]]; then
-    git apply "${PATCH}" "--directory=${ROOT}/llvm-project"
+    cd "${ROOT}/llvm-project"
+    git apply "${PATCH_TO_APPLY}" -v
+    cd "${ROOT}"
 fi
 
 # For older LLVM versions, merge runtime and projects

--- a/build/build.sh
+++ b/build/build.sh
@@ -14,6 +14,7 @@ BASENAME=clang
 NINJA_TARGET=install
 NINJA_TARGET_RUNTIMES=install-runtimes
 TAG=
+PATCH_TO_APPLY=
 
 case $VERSION in
 ce-trunk)
@@ -164,6 +165,7 @@ mlir-*)
     trunk)
         BRANCH=main
         VERSION=trunk-$(date +%Y%m%d)
+        PATCH_TO_APPLY=./patches/ce-debug-clang-trunk.patch
         ;;
     assertions-trunk)
         BRANCH=main
@@ -230,6 +232,10 @@ mkdir -p "${STAGING_DIR}"
 
 # Setup llvm-project checkout
 git clone --depth 1 --single-branch -b "${BRANCH}" "${URL}" "${ROOT}/llvm-project"
+
+if [[ -n "${PATCH_TO_APPLY}" ]]; then
+    git apply "${PATCH}" "--directory=${ROOT}/llvm-project"
+fi
 
 # For older LLVM versions, merge runtime and projects
 # August 2021 is when bootstrapping become necessary, bootstrapping might have been supported previously a few years prior

--- a/build/build.sh
+++ b/build/build.sh
@@ -174,6 +174,17 @@ mlir-*)
         ;;
     *)
         TAG=llvmorg-${VERSION}
+        case $VERSION in
+        "12.0.1" | "12.0.0")
+            PATCH_TO_APPLY=./patches/ce-debug-clang-12.patch
+            ;;
+        "11.0.1" | "11.0.0")
+            PATCH_TO_APPLY=./patches/ce-debug-clang-11.patch
+            ;;
+        *)
+            PATCH_TO_APPLY=./patches/ce-debug-clang-trunk.patch
+            ;;
+        esac
         ;;
     esac
     URL=https://github.com/llvm/llvm-project.git

--- a/build/build.sh
+++ b/build/build.sh
@@ -178,7 +178,7 @@ mlir-*)
         "12.0.1" | "12.0.0")
             PATCH_TO_APPLY=./patches/ce-debug-clang-12.patch
             ;;
-        "11.0.1" | "11.0.0")
+        "11.0.1" | "11.0.0" | "10.0.1" | "10.0.0")
             PATCH_TO_APPLY=./patches/ce-debug-clang-11.patch
             ;;
         *)

--- a/build/patches/ce-debug-clang-11.patch
+++ b/build/patches/ce-debug-clang-11.patch
@@ -1,0 +1,74 @@
+diff --git a/llvm/lib/Support/Debug.cpp b/llvm/lib/Support/Debug.cpp
+index 73b25d55237b..a8f6a7a3c9af 100644
+--- a/llvm/lib/Support/Debug.cpp
++++ b/llvm/lib/Support/Debug.cpp
+@@ -76,6 +76,11 @@ void setCurrentDebugTypes(const char **Types, unsigned Count) {
+ }
+ } // namespace llvm
+ 
++cl::opt<bool> LogDebugToStdOut(
++    "debug-to-stdout",
++    llvm::cl::desc("Log debugging to stdout instead of stderr"),
++    cl::init(false), cl::Hidden);
++
+ // All Debug.h functionality is a no-op in NDEBUG mode.
+ #ifndef NDEBUG
+ 
+@@ -130,23 +135,27 @@ static void debug_user_sig_handler(void *Cookie) {
+ 
+ /// dbgs - Return a circular-buffered debug stream.
+ raw_ostream &llvm::dbgs() {
+-  // Do one-time initialization in a thread-safe way.
+-  static struct dbgstream {
+-    circular_raw_ostream strm;
+-
+-    dbgstream() :
+-        strm(errs(), "*** Debug Log Output ***\n",
+-             (!EnableDebugBuffering || !DebugFlag) ? 0 : DebugBufferSize) {
+-      if (EnableDebugBuffering && DebugFlag && DebugBufferSize != 0)
+-        // TODO: Add a handler for SIGUSER1-type signals so the user can
+-        // force a debug dump.
+-        sys::AddSignalHandler(&debug_user_sig_handler, nullptr);
+-      // Otherwise we've already set the debug stream buffer size to
+-      // zero, disabling buffering so it will output directly to errs().
+-    }
+-  } thestrm;
+-
+-  return thestrm.strm;
++  if (LogDebugToStdOut) {
++    return outs();
++  } else {
++    // Do one-time initialization in a thread-safe way.
++    static struct dbgstream {
++      circular_raw_ostream strm;
++
++      dbgstream() :
++          strm(errs(), "*** Debug Log Output ***\n",
++                 (!EnableDebugBuffering || !DebugFlag) ? 0 : *DebugBufferSize) {
++        if (EnableDebugBuffering && DebugFlag && *DebugBufferSize != 0)
++          // TODO: Add a handler for SIGUSER1-type signals so the user can
++          // force a debug dump.
++          sys::AddSignalHandler(&debug_user_sig_handler, nullptr);
++        // Otherwise we've already set the debug stream buffer size to
++        // zero, disabling buffering so it will output directly to errs().
++      }
++    } thestrm;
++
++    return thestrm.strm;
++  }
+ }
+ 
+ #else
+@@ -154,7 +163,11 @@ raw_ostream &llvm::dbgs() {
+ namespace llvm {
+   /// dbgs - Return errs().
+   raw_ostream &dbgs() {
+-    return errs();
++    if (LogDebugToStdOut) {
++      return outs();
++    } else {
++      return errs();
++    }
+   }
+ }
+ 

--- a/build/patches/ce-debug-clang-12.patch
+++ b/build/patches/ce-debug-clang-12.patch
@@ -1,0 +1,74 @@
+diff --git a/llvm/lib/Support/Debug.cpp b/llvm/lib/Support/Debug.cpp
+index 73b25d55237b..c6aeaf57a71f 100644
+--- a/llvm/lib/Support/Debug.cpp
++++ b/llvm/lib/Support/Debug.cpp
+@@ -76,6 +76,11 @@ void setCurrentDebugTypes(const char **Types, unsigned Count) {
+ }
+ } // namespace llvm
+ 
++cl::opt<bool> LogDebugToStdOut(
++    "debug-to-stdout",
++    llvm::cl::desc("Log debugging to stdout instead of stderr"),
++    cl::init(false), cl::Hidden);
++
+ // All Debug.h functionality is a no-op in NDEBUG mode.
+ #ifndef NDEBUG
+ 
+@@ -130,23 +135,27 @@ static void debug_user_sig_handler(void *Cookie) {
+ 
+ /// dbgs - Return a circular-buffered debug stream.
+ raw_ostream &llvm::dbgs() {
+-  // Do one-time initialization in a thread-safe way.
+-  static struct dbgstream {
+-    circular_raw_ostream strm;
+-
+-    dbgstream() :
+-        strm(errs(), "*** Debug Log Output ***\n",
+-             (!EnableDebugBuffering || !DebugFlag) ? 0 : DebugBufferSize) {
+-      if (EnableDebugBuffering && DebugFlag && DebugBufferSize != 0)
+-        // TODO: Add a handler for SIGUSER1-type signals so the user can
+-        // force a debug dump.
+-        sys::AddSignalHandler(&debug_user_sig_handler, nullptr);
+-      // Otherwise we've already set the debug stream buffer size to
+-      // zero, disabling buffering so it will output directly to errs().
+-    }
+-  } thestrm;
+-
+-  return thestrm.strm;
++  if (LogDebugToStdOut) {
++    return outs();
++  } else {
++    // Do one-time initialization in a thread-safe way.
++    static struct dbgstream {
++      circular_raw_ostream strm;
++
++      dbgstream()
++          : strm(errs(), "*** Debug Log Output ***\n",
++                 (!EnableDebugBuffering || !DebugFlag) ? 0 : *DebugBufferSize) {
++        if (EnableDebugBuffering && DebugFlag && *DebugBufferSize != 0)
++          // TODO: Add a handler for SIGUSER1-type signals so the user can
++          // force a debug dump.
++          sys::AddSignalHandler(&debug_user_sig_handler, nullptr);
++        // Otherwise we've already set the debug stream buffer size to
++        // zero, disabling buffering so it will output directly to errs().
++      }
++    } thestrm;
++
++    return thestrm.strm;
++  }
+ }
+ 
+ #else
+@@ -154,7 +163,11 @@ raw_ostream &llvm::dbgs() {
+ namespace llvm {
+   /// dbgs - Return errs().
+   raw_ostream &dbgs() {
+-    return errs();
++    if (LogDebugToStdOut) {
++      return outs();
++    } else {
++      return errs();
++    }
+   }
+ }
+ 

--- a/build/patches/ce-debug-clang-trunk.patch
+++ b/build/patches/ce-debug-clang-trunk.patch
@@ -1,0 +1,238 @@
+commit 445c6dd4845daf2fbc5e8e8b9bac6a39cd90a470
+Author: partouf <partouf@gmail.com>
+Date:   Sat Dec 10 14:07:08 2022 +0100
+
+    change dbgs() in case of --debug-to-stdout
+
+diff --git a/llvm/lib/Support/Debug.cpp b/llvm/lib/Support/Debug.cpp
+index 98a9ac4722b5..a04aabe67627 100644
+--- a/llvm/lib/Support/Debug.cpp
++++ b/llvm/lib/Support/Debug.cpp
+@@ -1,196 +1,209 @@
+ //===-- Debug.cpp - An easy way to add debug output to your code ----------===//
+ //
+ // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ // See https://llvm.org/LICENSE.txt for license information.
+ // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ //
+ //===----------------------------------------------------------------------===//
+ //
+ // This file implements a handy way of adding debugging information to your
+ // code, without it being enabled all of the time, and without having to add
+ // command line options to enable it.
+ //
+ // In particular, just wrap your code with the LLVM_DEBUG() macro, and it will
+ // be enabled automatically if you specify '-debug' on the command-line.
+ // Alternatively, you can also use the SET_DEBUG_TYPE("foo") macro to specify
+ // that your debug code belongs to class "foo".  Then, on the command line, you
+ // can specify '-debug-only=foo' to enable JUST the debug information for the
+ // foo class.
+ //
+ // When compiling without assertions, the -debug-* options and all code in
+ // LLVM_DEBUG() statements disappears, so it does not affect the runtime of the
+ // code.
+ //
+ //===----------------------------------------------------------------------===//
+ 
+ #include "llvm/Support/Debug.h"
+ #include "llvm/Support/CommandLine.h"
+ #include "llvm/Support/ManagedStatic.h"
+ #include "llvm/Support/Signals.h"
+ #include "llvm/Support/circular_raw_ostream.h"
+ #include "llvm/Support/raw_ostream.h"
+ 
+ #include "DebugOptions.h"
+ 
+ #undef isCurrentDebugType
+ #undef setCurrentDebugType
+ #undef setCurrentDebugTypes
+ 
+ using namespace llvm;
+ 
+ // Even though LLVM might be built with NDEBUG, define symbols that the code
+ // built without NDEBUG can depend on via the llvm/Support/Debug.h header.
+ namespace llvm {
+ /// Exported boolean set by the -debug option.
+ bool DebugFlag = false;
+ 
+ static ManagedStatic<std::vector<std::string>> CurrentDebugType;
+ 
+ /// Return true if the specified string is the debug type
+ /// specified on the command line, or if none was specified on the command line
+ /// with the -debug-only=X option.
+ bool isCurrentDebugType(const char *DebugType) {
+   if (CurrentDebugType->empty())
+     return true;
+   // See if DebugType is in list. Note: do not use find() as that forces us to
+   // unnecessarily create an std::string instance.
+   for (auto &d : *CurrentDebugType) {
+     if (d == DebugType)
+       return true;
+   }
+   return false;
+ }
+ 
+ /// Set the current debug type, as if the -debug-only=X
+ /// option were specified.  Note that DebugFlag also needs to be set to true for
+ /// debug output to be produced.
+ ///
+ void setCurrentDebugTypes(const char **Types, unsigned Count);
+ 
+ void setCurrentDebugType(const char *Type) {
+   setCurrentDebugTypes(&Type, 1);
+ }
+ 
+ void setCurrentDebugTypes(const char **Types, unsigned Count) {
+   CurrentDebugType->clear();
+   for (size_t T = 0; T < Count; ++T)
+     CurrentDebugType->push_back(Types[T]);
+ }
+ } // namespace llvm
+ 
++cl::opt<bool> LogDebugToStdOut(
++    "debug-to-stdout",
++    llvm::cl::desc("Log debugging to stdout instead of stderr"),
++    cl::init(false), cl::Hidden);
++
+ // All Debug.h functionality is a no-op in NDEBUG mode.
+ #ifndef NDEBUG
+ 
+ namespace {
+ struct CreateDebug {
+   static void *call() {
+     return new cl::opt<bool, true>("debug", cl::desc("Enable debug output"),
+                                    cl::Hidden, cl::location(DebugFlag));
+   }
+ };
+ 
+ // -debug-buffer-size - Buffer the last N characters of debug output
+ //until program termination.
+ struct CreateDebugBufferSize {
+   static void *call() {
+     return new cl::opt<unsigned>(
+         "debug-buffer-size",
+         cl::desc("Buffer the last N characters of debug output "
+                  "until program termination. "
+                  "[default 0 -- immediate print-out]"),
+         cl::Hidden, cl::init(0));
+   }
+ };
+ } // namespace
+ 
+ // -debug - Command line option to enable the DEBUG statements in the passes.
+ // This flag may only be enabled in debug builds.
+ static ManagedStatic<cl::opt<bool, true>, CreateDebug> Debug;
+ static ManagedStatic<cl::opt<unsigned>, CreateDebugBufferSize> DebugBufferSize;
+ 
+ namespace {
+ 
+ struct DebugOnlyOpt {
+   void operator=(const std::string &Val) const {
+     if (Val.empty())
+       return;
+     DebugFlag = true;
+     SmallVector<StringRef,8> dbgTypes;
+     StringRef(Val).split(dbgTypes, ',', -1, false);
+     for (auto dbgType : dbgTypes)
+       CurrentDebugType->push_back(std::string(dbgType));
+   }
+ };
+ } // namespace
+ 
+ static DebugOnlyOpt DebugOnlyOptLoc;
+ 
+ namespace {
+ struct CreateDebugOnly {
+   static void *call() {
+     return new cl::opt<DebugOnlyOpt, true, cl::parser<std::string>>(
+         "debug-only",
+         cl::desc("Enable a specific type of debug output (comma separated list "
+                  "of types)"),
+         cl::Hidden, cl::value_desc("debug string"),
+         cl::location(DebugOnlyOptLoc), cl::ValueRequired);
+   }
+ };
+ } // namespace
+ 
+ static ManagedStatic<cl::opt<DebugOnlyOpt, true, cl::parser<std::string>>,
+                      CreateDebugOnly>
+     DebugOnly;
+ 
+ void llvm::initDebugOptions() {
+   *Debug;
+   *DebugBufferSize;
+   *DebugOnly;
+ }
+ 
+ // Signal handlers - dump debug output on termination.
+ static void debug_user_sig_handler(void *Cookie) {
+   // This is a bit sneaky.  Since this is under #ifndef NDEBUG, we
+   // know that debug mode is enabled and dbgs() really is a
+   // circular_raw_ostream.  If NDEBUG is defined, then dbgs() ==
+   // errs() but this will never be invoked.
+   llvm::circular_raw_ostream &dbgout =
+       static_cast<circular_raw_ostream &>(llvm::dbgs());
+   dbgout.flushBufferWithBanner();
+ }
+ 
+ /// dbgs - Return a circular-buffered debug stream.
+ raw_ostream &llvm::dbgs() {
+-  // Do one-time initialization in a thread-safe way.
+-  static struct dbgstream {
+-    circular_raw_ostream strm;
+-
+-    dbgstream()
+-        : strm(errs(), "*** Debug Log Output ***\n",
+-               (!EnableDebugBuffering || !DebugFlag) ? 0 : *DebugBufferSize) {
+-      if (EnableDebugBuffering && DebugFlag && *DebugBufferSize != 0)
+-        // TODO: Add a handler for SIGUSER1-type signals so the user can
+-        // force a debug dump.
+-        sys::AddSignalHandler(&debug_user_sig_handler, nullptr);
+-      // Otherwise we've already set the debug stream buffer size to
+-      // zero, disabling buffering so it will output directly to errs().
+-    }
+-  } thestrm;
+-
+-  return thestrm.strm;
++  if (LogDebugToStdOut) {
++    return outs();
++  } else {
++    // Do one-time initialization in a thread-safe way.
++    static struct dbgstream {
++      circular_raw_ostream strm;
++
++      dbgstream()
++          : strm(errs(), "*** Debug Log Output ***\n",
++                 (!EnableDebugBuffering || !DebugFlag) ? 0 : *DebugBufferSize) {
++        if (EnableDebugBuffering && DebugFlag && *DebugBufferSize != 0)
++          // TODO: Add a handler for SIGUSER1-type signals so the user can
++          // force a debug dump.
++          sys::AddSignalHandler(&debug_user_sig_handler, nullptr);
++        // Otherwise we've already set the debug stream buffer size to
++        // zero, disabling buffering so it will output directly to errs().
++      }
++    } thestrm;
++
++    return thestrm.strm;
++  }
+ }
+ 
+ #else
+ // Avoid "has no symbols" warning.
+ namespace llvm {
+   /// dbgs - Return errs().
+   raw_ostream &dbgs() {
+-    return errs();
++    if (LogDebugToStdOut) {
++      return outs();
++    } else {
++      return errs();
++    }
+   }
+ }
+ void llvm::initDebugOptions() {}
+ #endif
+ 
+ /// EnableDebugBuffering - Turn on signal handler installation.
+ ///
+ bool llvm::EnableDebugBuffering = false;

--- a/build/patches/ce-debug-clang-trunk.patch
+++ b/build/patches/ce-debug-clang-trunk.patch
@@ -8,84 +8,7 @@ diff --git a/llvm/lib/Support/Debug.cpp b/llvm/lib/Support/Debug.cpp
 index 98a9ac4722b5..a04aabe67627 100644
 --- a/llvm/lib/Support/Debug.cpp
 +++ b/llvm/lib/Support/Debug.cpp
-@@ -1,196 +1,209 @@
- //===-- Debug.cpp - An easy way to add debug output to your code ----------===//
- //
- // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
- // See https://llvm.org/LICENSE.txt for license information.
- // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
- //
- //===----------------------------------------------------------------------===//
- //
- // This file implements a handy way of adding debugging information to your
- // code, without it being enabled all of the time, and without having to add
- // command line options to enable it.
- //
- // In particular, just wrap your code with the LLVM_DEBUG() macro, and it will
- // be enabled automatically if you specify '-debug' on the command-line.
- // Alternatively, you can also use the SET_DEBUG_TYPE("foo") macro to specify
- // that your debug code belongs to class "foo".  Then, on the command line, you
- // can specify '-debug-only=foo' to enable JUST the debug information for the
- // foo class.
- //
- // When compiling without assertions, the -debug-* options and all code in
- // LLVM_DEBUG() statements disappears, so it does not affect the runtime of the
- // code.
- //
- //===----------------------------------------------------------------------===//
- 
- #include "llvm/Support/Debug.h"
- #include "llvm/Support/CommandLine.h"
- #include "llvm/Support/ManagedStatic.h"
- #include "llvm/Support/Signals.h"
- #include "llvm/Support/circular_raw_ostream.h"
- #include "llvm/Support/raw_ostream.h"
- 
- #include "DebugOptions.h"
- 
- #undef isCurrentDebugType
- #undef setCurrentDebugType
- #undef setCurrentDebugTypes
- 
- using namespace llvm;
- 
- // Even though LLVM might be built with NDEBUG, define symbols that the code
- // built without NDEBUG can depend on via the llvm/Support/Debug.h header.
- namespace llvm {
- /// Exported boolean set by the -debug option.
- bool DebugFlag = false;
- 
- static ManagedStatic<std::vector<std::string>> CurrentDebugType;
- 
- /// Return true if the specified string is the debug type
- /// specified on the command line, or if none was specified on the command line
- /// with the -debug-only=X option.
- bool isCurrentDebugType(const char *DebugType) {
-   if (CurrentDebugType->empty())
-     return true;
-   // See if DebugType is in list. Note: do not use find() as that forces us to
-   // unnecessarily create an std::string instance.
-   for (auto &d : *CurrentDebugType) {
-     if (d == DebugType)
-       return true;
-   }
-   return false;
- }
- 
- /// Set the current debug type, as if the -debug-only=X
- /// option were specified.  Note that DebugFlag also needs to be set to true for
- /// debug output to be produced.
- ///
- void setCurrentDebugTypes(const char **Types, unsigned Count);
- 
- void setCurrentDebugType(const char *Type) {
-   setCurrentDebugTypes(&Type, 1);
- }
- 
- void setCurrentDebugTypes(const char **Types, unsigned Count) {
-   CurrentDebugType->clear();
-   for (size_t T = 0; T < Count; ++T)
-     CurrentDebugType->push_back(Types[T]);
+@@ -78,6 +78,11 @@ void setCurrentDebugTypes(const char **Types, unsigned Count) {
  }
  } // namespace llvm
  
@@ -97,83 +20,7 @@ index 98a9ac4722b5..a04aabe67627 100644
  // All Debug.h functionality is a no-op in NDEBUG mode.
  #ifndef NDEBUG
  
- namespace {
- struct CreateDebug {
-   static void *call() {
-     return new cl::opt<bool, true>("debug", cl::desc("Enable debug output"),
-                                    cl::Hidden, cl::location(DebugFlag));
-   }
- };
- 
- // -debug-buffer-size - Buffer the last N characters of debug output
- //until program termination.
- struct CreateDebugBufferSize {
-   static void *call() {
-     return new cl::opt<unsigned>(
-         "debug-buffer-size",
-         cl::desc("Buffer the last N characters of debug output "
-                  "until program termination. "
-                  "[default 0 -- immediate print-out]"),
-         cl::Hidden, cl::init(0));
-   }
- };
- } // namespace
- 
- // -debug - Command line option to enable the DEBUG statements in the passes.
- // This flag may only be enabled in debug builds.
- static ManagedStatic<cl::opt<bool, true>, CreateDebug> Debug;
- static ManagedStatic<cl::opt<unsigned>, CreateDebugBufferSize> DebugBufferSize;
- 
- namespace {
- 
- struct DebugOnlyOpt {
-   void operator=(const std::string &Val) const {
-     if (Val.empty())
-       return;
-     DebugFlag = true;
-     SmallVector<StringRef,8> dbgTypes;
-     StringRef(Val).split(dbgTypes, ',', -1, false);
-     for (auto dbgType : dbgTypes)
-       CurrentDebugType->push_back(std::string(dbgType));
-   }
- };
- } // namespace
- 
- static DebugOnlyOpt DebugOnlyOptLoc;
- 
- namespace {
- struct CreateDebugOnly {
-   static void *call() {
-     return new cl::opt<DebugOnlyOpt, true, cl::parser<std::string>>(
-         "debug-only",
-         cl::desc("Enable a specific type of debug output (comma separated list "
-                  "of types)"),
-         cl::Hidden, cl::value_desc("debug string"),
-         cl::location(DebugOnlyOptLoc), cl::ValueRequired);
-   }
- };
- } // namespace
- 
- static ManagedStatic<cl::opt<DebugOnlyOpt, true, cl::parser<std::string>>,
-                      CreateDebugOnly>
-     DebugOnly;
- 
- void llvm::initDebugOptions() {
-   *Debug;
-   *DebugBufferSize;
-   *DebugOnly;
- }
- 
- // Signal handlers - dump debug output on termination.
- static void debug_user_sig_handler(void *Cookie) {
-   // This is a bit sneaky.  Since this is under #ifndef NDEBUG, we
-   // know that debug mode is enabled and dbgs() really is a
-   // circular_raw_ostream.  If NDEBUG is defined, then dbgs() ==
-   // errs() but this will never be invoked.
-   llvm::circular_raw_ostream &dbgout =
-       static_cast<circular_raw_ostream &>(llvm::dbgs());
-   dbgout.flushBufferWithBanner();
- }
+@@ -161,23 +166,27 @@ static void debug_user_sig_handler(void *Cookie) {
  
  /// dbgs - Return a circular-buffered debug stream.
  raw_ostream &llvm::dbgs() {
@@ -218,7 +65,7 @@ index 98a9ac4722b5..a04aabe67627 100644
  }
  
  #else
- // Avoid "has no symbols" warning.
+@@ -185,7 +194,11 @@ raw_ostream &llvm::dbgs() {
  namespace llvm {
    /// dbgs - Return errs().
    raw_ostream &dbgs() {
@@ -231,8 +78,3 @@ index 98a9ac4722b5..a04aabe67627 100644
    }
  }
  void llvm::initDebugOptions() {}
- #endif
- 
- /// EnableDebugBuffering - Turn on signal handler installation.
- ///
- bool llvm::EnableDebugBuffering = false;


### PR DESCRIPTION
Does patch application work on:

* [x] trunk
* [x] llvmorg-10.0.0 - v11 patch
* [x] llvmorg-10.0.1 - v11 patch
* [x] llvmorg-11.0.1 - v11 patch
* [x] llvmorg-12.0.0 - v12 patch
* [x] llvmorg-12.0.1 - v12 patch
* [x] llvmorg-13.0.0
* [x] llvmorg-13.0.1
* [x] llvmorg-14.0.0
* [x] llvmorg-15.0.0


To build:

* [ ] trunk (works in ce-trunk)
* [ ] llvmorg-10.0.0
* [ ] llvmorg-10.0.1
* [ ] llvmorg-11.0.1
* [ ] llvmorg-12.0.0
* [ ] llvmorg-12.0.1
* [ ] llvmorg-13.0.0
* [ ] llvmorg-13.0.1
* [ ] llvmorg-14.0.0
* [ ] llvmorg-15.0.0
