### PR TITLE
Enable experimental M68K backend

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -191,7 +191,7 @@ mlir-*)
     URL=https://github.com/llvm/llvm-project.git
     LLVM_ENABLE_PROJECTS="clang;lld;polly;clang-tools-extra"
     LLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;compiler-rt;openmp"
-    LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="RISCV;WebAssembly"
+    LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="M68K;WebAssembly"
     ;;
 esac
 


### PR DESCRIPTION
Enable the experimental M68K.
Cleanup the RISCV that is not experimental anymore.

refs https://github.com/compiler-explorer/compiler-explorer/issues/4904

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>