### PR TITLE
Update CMAKE_EXTRA_ARGS for widberg-main

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -62,6 +62,7 @@ widberg-main)
     BRANCH=main
     URL=https://github.com/widberg/llvm-project-widberg-extensions.git
     VERSION=widberg-main-$(date +%Y%m%d)
+    CMAKE_EXTRA_ARGS+=("-DCMAKE_BUILD_TYPE=RelWithDebInfo" "-DLLVM_ENABLE_ASSERTIONS=ON" "-DLLVM_TARGETS_TO_BUILD=X86")
     ;;
 mizvekov-resugar)
     BRANCH=resugar


### PR DESCRIPTION
The widberg clang fork is still in development so it would be useful to have debug info and assertions available in the compiler output. While `-DCMAKE_BUILD_TYPE:STRING=Release` is set for all targets, specifying `-DCMAKE_BUILD_TYPE=RelWithDebInfo` in `CMAKE_EXTRA_ARGS` should override that default for widberg-main since `CMAKE_EXTRA_ARGS` comes at the end of the argument list. If there is a reason to not build with debug symbols, i.e. space, that's fine, assertions alone would be fine. Also, it only supports X86 so I set `LLVM_TARGETS_TO_BUILD` accordingly.