### PR TITLE
Move HLSL and DirectX/SPIRV support to the trunk build

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -141,8 +141,6 @@ llvm-*)
     if [[ "${VERSION}" == "trunk" ]]; then
         BRANCH=main
         VERSION=trunk-$(date +%Y%m%d)
-        CMAKE_EXTRA_ARGS+=("-DCLANG_ENABLE_HLSL=On")
-        LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="DirectX;SPIRV"
     else
         TAG=llvmorg-${VERSION}
     fi
@@ -216,7 +214,8 @@ mlir-*)
             LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="WebAssembly"
         else
             PATCHES_TO_APPLY+=("${ROOT}/patches/ce-debug-clang-trunk.patch")
-            LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="M68k;WebAssembly"
+            LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="DirectX;SPIRV;M68k;WebAssembly"
+            CMAKE_EXTRA_ARGS+=("-DCLANG_ENABLE_HLSL=On")
         fi
         ;;
     esac


### PR DESCRIPTION
When @llvm-beanz attempted to add HLSL support here this was added this under the `llvm-*` build targets, but those are actually used for the "library" builds of LLVM, not the compilers themselves.

Move this support under the trunk part of the `*` target like other experimental targets. This should make it so that the current "clang" option for HLSL stops giving errors about missing "hlsl.h" and should be useable for basic compute shaders.