### PR TITLE
Move HLSL and DirectX/SPIRV support to the trunk build (Attempt 2)

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -171,6 +171,8 @@ mlir-*)
         BRANCH=main
         VERSION=trunk-$(date +%Y%m%d)
         PATCHES_TO_APPLY+=("${ROOT}/patches/ce-debug-clang-trunk.patch")
+        LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="DirectX;SPIRV"
+        CMAKE_EXTRA_ARGS+=("-DCLANG_ENABLE_HLSL=On")
         ;;
     assertions-trunk)
         BRANCH=main
@@ -217,8 +219,7 @@ mlir-*)
             LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="WebAssembly"
         else
             PATCHES_TO_APPLY+=("${ROOT}/patches/ce-debug-clang-trunk.patch")
-            LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="DirectX;SPIRV;M68k;WebAssembly"
-            CMAKE_EXTRA_ARGS+=("-DCLANG_ENABLE_HLSL=On")
+            LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="M68k;WebAssembly"
         fi
         ;;
     esac


### PR DESCRIPTION
In my previous attempt at doing this in 1e799cd I misread the case labels and actually modified the build for clang with a specific version, rather than modifying trunk like I said I was doing.

Here we revert the "specific-version that is above clang-12" case to what it was before and actually put the DirectX, SPIRV, and HLSL flags in the trunk build itself.