### PR TITLE
Add support for ClangIR llvm fork

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -98,6 +98,13 @@ patmat-trunk)
     URL=https://github.com/bcardosolopes/llvm-project.git
     VERSION=patmat-trunk-$(date +%Y%m%d)
     ;;
+clangir-trunk)
+    BRANCH=llvmorg-master-pattern-matching
+    URL=https://github.com/llvm/clangir.git
+    VERSION=clangir-trunk-$(date +%Y%m%d)
+    LLVM_ENABLE_PROJECTS="clang;mlir;cir"
+    CMAKE_EXTRA_ARGS+=( "-DLLVM_ENABLE_ASSERTIONS=ON" "-DLLVM_TARGETS_TO_BUILD=X86;AArch64;ARM")
+    ;;
 reflection-trunk)
     BRANCH=reflection
     URL=https://github.com/matus-chochlik/llvm-project.git


### PR DESCRIPTION
ClangIR is a new IR for clang (clangir.org) hosted in LLVM's umbrella of projects. ClangIR is a C/C++ dialect for MLIR built into Clang.

Enable support for ClangIR as part of the compiler-explorer by setting up repos and build configurations.

I'm a big fan of the compiler-explorer and would be great if we can incorporate support for our project, thanks! :)

More context in https://github.com/compiler-explorer/infra/issues/1070