### PR TITLE
Fix bad copy-past for ClangIR branch

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -99,7 +99,7 @@ patmat-trunk)
     VERSION=patmat-trunk-$(date +%Y%m%d)
     ;;
 clangir-trunk)
-    BRANCH=llvmorg-master-pattern-matching
+    BRANCH=main
     URL=https://github.com/llvm/clangir.git
     VERSION=clangir-trunk-$(date +%Y%m%d)
     LLVM_ENABLE_PROJECTS="clang;mlir;cir"


### PR DESCRIPTION
Follow up from mistake in #51 