### PR TITLE
Add M68K target to clang trunk

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -183,7 +183,7 @@ mlir-*)
         BRANCH=main
         VERSION=trunk-$(date +%Y%m%d)
         PATCHES_TO_APPLY+=("${ROOT}/patches/ce-debug-clang-trunk.patch")
-        LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="DirectX;SPIRV"
+        LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="DirectX;SPIRV;M68k"
         CMAKE_EXTRA_ARGS+=("-DCLANG_ENABLE_HLSL=On")
         ;;
     assertions-trunk)


### PR DESCRIPTION
Currently choosing "M68k clang (trunk)" results in:
```
error: unable to create target: 'No available targets are compatible with triple "m68k"'
```

M68k is an experimental target so it needs to be added to LLVM_EXPERIMENTAL_TARGETS_TO_BUILD to be included in clang.

I also checked locally that `-target m68k` is correct, so once clang has the target it should start working.

```
$ ./bin/clang -target m68k /tmp/test.c -S -o -
        .text
        .file   "test.c"
        .globl  square                          ; -- Begin function square
<...>
```

Refs: https://github.com/compiler-explorer/compiler-explorer/issues/271