### PR TITLE
Fix llvmflang-trunk build by using gcc 9.4.0 instead of 9.2.0

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -79,6 +79,8 @@ lifetime-trunk)
     LLVM_ENABLE_RUNTIMES=""
     ;;
 llvmflang-trunk)
+    # Does not compile with 9.2.0.
+    GCC_VERSION=9.4.0
     BRANCH=main
     URL=https://github.com/llvm/llvm-project.git
     VERSION=llvmflang-trunk-$(date +%Y%m%d)


### PR DESCRIPTION
The flang build has been failing for a long time with errors about constant expressions:
```
/root/llvm-project/flang/include/flang/Common/enum-class.h: In static member function 'static std::string_view Fortran::parser::DefinedOperator::EnumToString(Fortran::parser::DefinedOperator::IntrinsicOperator)':
/root/llvm-project/flang/include/flang/Parser/parse-tree.h:600:3:   in 'constexpr' expansion of 'Fortran::common::EnumNames<17>(((const char*)(& vaArgs)))'
/root/llvm-project/flang/include/flang/Common/enum-class.h:51:16: error: '(((const char*)(& vaArgs)) == 0)' is not a constant expression
   51 |     } else if (!start) {
      |                ^~~~~~
```

There is a source level workaround for this (pass `__VA_ARGS__` directly to `EnumNames`) but the resulting build fails some basic tests, so I don't think it would be a good idea to use it.

My local system has a gcc 9.4.0 which compiles and tests all pass.

I was able to reproduce the 9.2.0 failure locally, but not on Compiler Explorer. I am missing some aspect of how this macro is used I expect.

This change relates to https://github.com/compiler-explorer/compiler-explorer/issues/4334.