### PR TITLE
Lower LLVM Flang compile jobs to 12

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -88,7 +88,7 @@ llvmflang-trunk)
     LLVM_ENABLE_RUNTIMES=""
     NINJA_TARGET_RUNTIMES=
     # See https://github.com/compiler-explorer/clang-builder/issues/27
-    CMAKE_EXTRA_ARGS+=("-DCMAKE_CXX_STANDARD=17" "-DLLVM_PARALLEL_COMPILE_JOBS=24")
+    CMAKE_EXTRA_ARGS+=("-DCMAKE_CXX_STANDARD=17" "-DLLVM_PARALLEL_COMPILE_JOBS=12")
     ;;
 relocatable-trunk)
     BRANCH=trivially-relocatable


### PR DESCRIPTION
Since cf8a1d5493a3ced2e32f34e4bc5451f065006078, the build appears to be progressing further than it was. However it is always losing connection with the runner.

```
The self-hosted runner: i-0204e679ec369bc12 lost communication with the server.
Verify the machine is running and has a healthy network connection.
Anything in your workflow that terminates the runner process, starves it for CPU/Memory,
or blocks its network access can cause this error.
```

https://github.com/compiler-explorer/compiler-workflows/actions/runs/6975336754

This is always happening around the 40 minute mark, so my assumption is that Flang's unusally high RAM requirements for compilation are indeed starving the machine of memory.

At 12 jobs it might take a very long time, but at least if we hit a timeout we'll be able to see the logs and adjust from there.