### PR TITLE
Use libunwind for recent clang versions

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -29,6 +29,7 @@ autonsdmi-trunk)
     URL=https://github.com/cor3ntin/llvm-project.git
     VERSION=autonsdmi-trunk-$(date +%Y%m%d)
     CMAKE_EXTRA_ARGS+=("-DLLVM_OPTIMIZED_TABLEGEN=ON")
+    LLVM_ENABLE_RUNTIMES+=";libunwind"
     ;;
 cppx-trunk)
     BRANCH=compiler-explorer
@@ -187,6 +188,7 @@ mlir-*)
         PATCHES_TO_APPLY+=("${ROOT}/patches/ce-debug-clang-trunk.patch")
         LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="DirectX;SPIRV;M68k"
         CMAKE_EXTRA_ARGS+=("-DCLANG_ENABLE_HLSL=On")
+        LLVM_ENABLE_RUNTIMES+=";libunwind"
         ;;
     assertions-trunk)
         BRANCH=main


### PR DESCRIPTION
libunwind is required to build libc++ as of
https://github.com/llvm/llvm-project/pull/77687#issuecomment-1890582294

It was already used for numbered versions, but not trunk.

I also  updated my branch and left everything else alone as I did not know whether they use version of clang that can build libunwind