### PR TITLE
Install libc++ modules std and std.compat

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -187,13 +187,13 @@ mlir-*)
         VERSION=trunk-$(date +%Y%m%d)
         PATCHES_TO_APPLY+=("${ROOT}/patches/ce-debug-clang-trunk.patch")
         LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="DirectX;SPIRV;M68k"
-        CMAKE_EXTRA_ARGS+=("-DCLANG_ENABLE_HLSL=On")
+        CMAKE_EXTRA_ARGS+=("-DCLANG_ENABLE_HLSL=On" "-DLIBCXX_INSTALL_MODULES=ON")
         LLVM_ENABLE_RUNTIMES+=";libunwind"
         ;;
     assertions-trunk)
         BRANCH=main
         VERSION=assertions-trunk-$(date +%Y%m%d)
-        CMAKE_EXTRA_ARGS+=("-DLLVM_ENABLE_ASSERTIONS=ON")
+        CMAKE_EXTRA_ARGS+=("-DLLVM_ENABLE_ASSERTIONS=ON" "-DLIBCXX_INSTALL_MODULES=ON")
         LLVM_ENABLE_RUNTIMES+=";libunwind"
         PATCHES_TO_APPLY+=("${ROOT}/patches/ce-debug-clang-trunk.patch")
         ;;
@@ -236,6 +236,10 @@ mlir-*)
         else
             PATCHES_TO_APPLY+=("${ROOT}/patches/ce-debug-clang-trunk.patch")
             LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="M68k;WebAssembly"
+        fi
+
+        if [[ $MAJOR -ge 18 ]]; then
+            CMAKE_EXTRA_ARGS+=("-DLIBCXX_INSTALL_MODULES=ON")
         fi
         ;;
     esac


### PR DESCRIPTION
This allows user harcoding the path in CMake such as:
```cmake
target_sources(std-cxx-modules
  PUBLIC
    FILE_SET moduleStd
    TYPE CXX_MODULES
    BASE_DIRS /opt/compiler-explorer/clang-trunk/modules/c++/v1
    FILES
      /opt/compiler-explorer/clang-trunk/modules/c++/v1/std.cppm
      /opt/compiler-explorer/clang-trunk/modules/c++/v1/std.compat.cppm)
```
and can also be used by CMake when the module std support lands in the future.
Ref: https://github.com/compiler-explorer/compiler-explorer/issues/5404#issuecomment-1919116649