### PR TITLE
Use libunwind for P1144 fork

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -95,6 +95,7 @@ relocatable-trunk)
     BRANCH=trivially-relocatable
     URL=https://github.com/Quuxplusone/llvm-project.git
     VERSION=relocatable-trunk-$(date +%Y%m%d)
+    LLVM_ENABLE_RUNTIMES+=";libunwind"
     ;;
 patmat-trunk)
     BRANCH=llvmorg-master-pattern-matching


### PR DESCRIPTION
Applies ce1b0554 to my P1144 fork, hopefully fixing the build that's been failing since January 2024.

(Most recent failing build: https://github.com/compiler-explorer/compiler-workflows/actions/runs/7909028391/job/21589342251 )