### PR TITLE
Add libunwind to the enabled runtime list of clangir build

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -107,6 +107,7 @@ clangir-trunk)
     URL=https://github.com/llvm/clangir.git
     VERSION=clangir-trunk-$(date +%Y%m%d)
     LLVM_ENABLE_PROJECTS="clang;mlir"
+    LLVM_ENABLE_RUNTIMES="libunwind;libcxx;libcxxabi"
     CMAKE_EXTRA_ARGS+=( "-DCLANG_ENABLE_CIR=ON" "-DLLVM_ENABLE_ASSERTIONS=ON" "-DLLVM_TARGETS_TO_BUILD=X86;AArch64;ARM")
     ;;
 reflection-trunk)


### PR DESCRIPTION
Following the comments in #61 , this PR adds `libunwind`, `libcxx`, and `libcxxabi` to the list of enabled runtimes when building `clangir-trunk`.