### PR TITLE
Added git attributes file to ensure correct line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+/build/** eol=lf


### PR DESCRIPTION
This was helpful in testing changes on Windows.  Everything inside `build` needs traditional Unix line endings.