### PR TITLE
Added p2998 (deducing more template arguments from a function call)

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -130,6 +130,12 @@ bb-p2996-trunk)
     VERSION=bb-p2996-trunk-$(date +%Y%m%d)
     LLVM_ENABLE_RUNTIMES+=";libunwind"
     ;;
+p2998-trunk)
+    BRANCH=p2998
+    URL=https://github.com/Bekenn/llvm-project
+    VERSION=p2998-trunk-$(date +%Y%m%d)
+    LLVM_ENABLE_RUNTIMES+=";libunwind"
+    ;;
 p3068-trunk)
     BRANCH=P3068-constexpr-exceptions
     URL=https://github.com/hanickadot/llvm-project


### PR DESCRIPTION
See [P2998R0](https://wg21.link/p2998) for details.  This implements three features:

* User-declared guides for alias templates
* Multiple return types on deduction guides
* Deduction of additional template arguments from a function call

Requires `-p2998` on the Clang command line to activate new features.