### PR TITLE
Fix ClangIR build

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -107,6 +107,8 @@ patmat-trunk)
     LLVM_ENABLE_RUNTIMES+=";libunwind"
     ;;
 clangir-trunk)
+    # Does not compile with 9.2.0.
+    GCC_VERSION=14.2.0
     BRANCH=main
     URL=https://github.com/llvm/clangir.git
     VERSION=clangir-trunk-$(date +%Y%m%d)


### PR DESCRIPTION
Similar to Flang (and likely for similar reasons), gcc 9.2 fails to build ClangIR. I confirmed that 9.4.0 (which works for Flang) also works for ClangIR, but it should be more future-proof to use the latest and greatest gcc version. (Many ClangIR developers use Clang as their host compiler, so a recent gcc should match that better.)

Fixes #75