### PR TITLE
Update default base image to 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG image=20.04
+ARG image=22.04
 FROM ubuntu:${image}
 LABEL maintainer="Matt Godbolt <matt@godbolt.org>"
 ARG image # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact


### PR DESCRIPTION
Brings us in line with GCC, and that means
we can run GCCs built by the gcc-builder newer than 14.

See also compiler-explorer/clang-builder#78