### PR TITLE
Fix build of clang "resugar" experimental variant

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -73,7 +73,8 @@ mizvekov-resugar)
     BRANCH=resugar
     URL=https://github.com/mizvekov/llvm-project.git
     VERSION=mizvekov-resugar-$(date +%Y%m%d)
-    CMAKE_EXTRA_ARGS+=("-DLLVM_ENABLE_ASSERTIONS=ON")
+    CMAKE_EXTRA_ARGS+=("-DLLVM_ENABLE_ASSERTIONS=ON" "-DLLVM_OPTIMIZED_TABLEGEN=ON")
+    LLVM_ENABLE_RUNTIMES+=";libunwind"
     ;;
 lifetime-trunk)
     BRANCH=lifetime


### PR DESCRIPTION
This adds libunwind to the list of runtimes, and uses optimized tablegen for faster build, since assertions are enabled.