### PR TITLE
Add AArch64 and ARM targets to the "relocatable" (P1144) builder

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -104,6 +104,7 @@ relocatable-trunk)
     VERSION=relocatable-trunk-$(date +%Y%m%d)
     LLVM_ENABLE_PROJECTS="clang"
     LLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi;libunwind"
+    CMAKE_EXTRA_ARGS+=("-DLLVM_ENABLE_ASSERTIONS=ON" "-DLLVM_TARGETS_TO_BUILD=AArch64;ARM;X86")
     ;;
 patmat-trunk)
     BRANCH=p2688-pattern-matching


### PR DESCRIPTION
I think this might at least partly address what I asked on Slack on April 26th: how to get the compiler on godbolt.org to show ARM64 assembly if you pass the right options. (My latest attempt to get this compiler to produce armv8.3-a assembly: https://godbolt.org/z/ojvYb3ao5 ) However, I'm definitely not _sure_ if this even helps. FWIW, I bet my confusion is more with how to use the Clang driver than with how Clang is built.

Also enable assertions within the compiler itself, since there's no particular downside to that that I can see.