### PR TITLE
Add P3385 experimental clang compiler

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -168,6 +168,12 @@ p3372-trunk)
     VERSION=p3372-trunk-$(date +%Y%m%d)
     LLVM_ENABLE_RUNTIMES+=";libunwind"
     ;;
+p3385-trunk)
+    BRANCH=3385R5
+    URL=https://github.com/zebullax/clang-p2996/
+    VERSION=p3385-trunk-$(date +%Y%m%d)
+    LLVM_ENABLE_RUNTIMES+=";libunwind"
+    ;;
 p3412-trunk)
     BRANCH=f-literals
     URL=https://github.com/BengtGustafsson/llvm-project-UTP.git


### PR DESCRIPTION
P3385 introduce reflection for attributes, adding this (first-time contrib) experimental branch for public use.

_(I am following what was done in https://github.com/compiler-explorer/compiler-explorer/pull/7175_)
- [x] clang-builder : this
- [x] compiler-workflow: [here](https://github.com/compiler-explorer/compiler-workflows/pull/37)
- [x] compiler-explorer: [here](https://github.com/compiler-explorer/compiler-explorer/pull/7910)
- [x] infra: [here](https://github.com/compiler-explorer/infra/pull/1706)

@mattgodbolt  LMK if you want me to spawn those PR **now**, or I shall raise them once this one is merged.