### PR TITLE
Be consistent about trunk's experimental targets

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -303,7 +303,7 @@ mlir-*)
         BRANCH=main
         VERSION=trunk-$(date +%Y%m%d)
         PATCHES_TO_APPLY+=("${ROOT}/patches/ce-debug-clang-trunk.patch")
-        LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="DirectX;SPIRV;M68k"
+        LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="DirectX;M68k"
         CMAKE_EXTRA_ARGS+=("-DCLANG_ENABLE_HLSL=On" "-DLIBCXX_INSTALL_MODULES=ON")
         LLVM_ENABLE_RUNTIMES+=";libunwind"
         ;;
@@ -318,7 +318,8 @@ mlir-*)
     assertions-trunk)
         BRANCH=main
         VERSION=assertions-trunk-$(date +%Y%m%d)
-        CMAKE_EXTRA_ARGS+=("-DLLVM_ENABLE_ASSERTIONS=ON" "-DLIBCXX_INSTALL_MODULES=ON")
+        LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="DirectX;M68k"
+        CMAKE_EXTRA_ARGS+=("-DLLVM_ENABLE_ASSERTIONS=ON" "-DCLANG_ENABLE_HLSL=On" "-DLIBCXX_INSTALL_MODULES=ON")
         LLVM_ENABLE_RUNTIMES+=";libunwind"
         PATCHES_TO_APPLY+=("${ROOT}/patches/ce-debug-clang-trunk.patch")
         ;;


### PR DESCRIPTION
This updates `assertions-trunk` to match `trunk` with respect to experimental targets.

- We no longer need to list SPIRV in experimental targets - it was promoted out of experimental back in January.
- The DirectX and M68k targets will now be available in asserts.
- The DirectX target isn't very useful without HLSL support, so this adds the `-DCLANG_ENABLE_HLSL=On` flag as well.