### PR TITLE
🐛 Workaround GCC name conflict in DXContainerYAML.h (llvm#198222)

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -373,6 +373,7 @@ mlir-*)
         BRANCH=main
         VERSION=trunk-$(date +%Y%m%d)
         PATCHES_TO_APPLY+=("${ROOT}/patches/ce-debug-clang-trunk.patch")
+        PATCHES_TO_APPLY+=("${ROOT}/patches/ce-dxcontainer-gcc-name-conflict.patch") # TODO: remove when llvm#198222 is fixed upstream
         LLVM_EXPERIMENTAL_TARGETS_TO_BUILD="DirectX;M68k"
         CMAKE_EXTRA_ARGS+=("-DCLANG_ENABLE_HLSL=On" "-DLIBCXX_INSTALL_MODULES=ON")
         LLVM_ENABLE_RUNTIMES+=";libunwind"
@@ -381,6 +382,7 @@ mlir-*)
         BRANCH=main
         VERSION=trunk-aarch64-$(date +%Y%m%d)
         PATCHES_TO_APPLY+=("${ROOT}/patches/ce-debug-clang-trunk.patch")
+        PATCHES_TO_APPLY+=("${ROOT}/patches/ce-dxcontainer-gcc-name-conflict.patch") # TODO: remove when llvm#198222 is fixed upstream
         LLVM_EXPERIMENTAL_TARGETS_TO_BUILD=""
         CMAKE_EXTRA_ARGS+=("-DLIBCXX_INSTALL_MODULES=ON -DLLVM_TARGETS_TO_BUILD=AArch64")
         LLVM_ENABLE_RUNTIMES+=";libunwind"
@@ -392,6 +394,7 @@ mlir-*)
         CMAKE_EXTRA_ARGS+=("-DLLVM_ENABLE_ASSERTIONS=ON" "-DCLANG_ENABLE_HLSL=On" "-DLIBCXX_INSTALL_MODULES=ON")
         LLVM_ENABLE_RUNTIMES+=";libunwind"
         PATCHES_TO_APPLY+=("${ROOT}/patches/ce-debug-clang-trunk.patch")
+        PATCHES_TO_APPLY+=("${ROOT}/patches/ce-dxcontainer-gcc-name-conflict.patch") # TODO: remove when llvm#198222 is fixed upstream
         ;;
     *)
         # Handle assertions-{VERSION}

--- a/build/patches/ce-dxcontainer-gcc-name-conflict.patch
+++ b/build/patches/ce-dxcontainer-gcc-name-conflict.patch
@@ -1,0 +1,11 @@
+--- a/llvm/include/llvm/ObjectYAML/DXContainerYAML.h
++++ b/llvm/include/llvm/ObjectYAML/DXContainerYAML.h
+@@ -325,7 +325,7 @@
+   std::optional<DXContainerYAML::Signature> Signature;
+   std::optional<DXContainerYAML::RootSignatureYamlDesc> RootSignature;
+   std::optional<DXContainerYAML::DebugName> DebugName;
+-  std::optional<CompilerVersion> CompilerVersion;
++  std::optional<struct CompilerVersion> CompilerVersion;
+ };
+ 
+ struct Object {


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Following on from #109, the daily clang trunk build is still failing due to a brand-new LLVM trunk bug introduced today at 13:52 UTC by llvm/llvm-project#198222.

**Root cause:** That PR added a `CompilerVersion` member inside `struct Part` with the same name as the outer `struct CompilerVersion`. GCC errors on this with `-fpermissive` because it "changes meaning" of the name `CompilerVersion` within the class scope. Clang is more permissive and doesn't error.

**Error:**
```
llvm/include/llvm/ObjectYAML/DXContainerYAML.h:328:34: error: declaration of
  'std::optional<...CompilerVersion> ...Part::CompilerVersion' changes meaning of
  'CompilerVersion' [-fpermissive]
```

**Fix:** Use an elaborated type specifier (`struct CompilerVersion`) for the member declaration, which forces the compiler to resolve it as a struct tag rather than the (not-yet-declared) member name. One-line change.

This is a temporary workaround — there's a TODO comment in build.sh to remove it once llvm/llvm-project#198222 is fixed upstream.