### PR TITLE
Update ClangIR build config to point to the upstream

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -136,7 +136,7 @@ clangir-trunk)
     # Does not compile with 9.2.0.
     GCC_VERSION=14.2.0
     BRANCH=main
-    URL=https://github.com/llvm/clangir.git
+    URL=https://github.com/llvm/llvm-project.git
     VERSION=clangir-trunk-$(date +%Y%m%d)
     LLVM_ENABLE_PROJECTS="clang;mlir"
     LLVM_ENABLE_RUNTIMES="libunwind;libcxx;libcxxabi"


### PR DESCRIPTION
The ClangIR incubator repository is not publicly archived since the project has now been upstreamed in the LLVM repo source tree, and there are some changes and improvements during the upstream process, so it will be much more helpful and useful for the users to point directly to the active upstream repository