### PR TITLE
setting default stdlib for clang contracts-p3850 branch

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -273,6 +273,7 @@ notadragon-contracts-p3850)
     URL=https://github.com/notadragon/llvm-project
     VERSION=notadragon-contracts-p3850-$(date +%Y%m%d)
     LLVM_ENABLE_RUNTIMES+=";libunwind"
+    CMAKE_EXTRA_ARGS+=("-DCLANG_DEFAULT_CXX_STDLIB=libc++")
     ;;
 p1974-trunk)
     BRANCH=godbolt/propconst


### PR DESCRIPTION
The clang contracts-p3850 branch does not yet work correctly with libstdc++ (and most features would need the new libstdc++ from the corresponding gcc branch anyway) so changing the default stdlib when building this clang version.