### PR TITLE
Add p3817-trunk build config

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -224,6 +224,12 @@ p3776-trunk)
     VERSION=p3776-trunk-$(date +%Y%m%d)
     LLVM_ENABLE_RUNTIMES+=";libunwind"
     ;;
+p3817-trunk)
+    BRANCH=p3817
+    URL=https://github.com/regevran/llvm-project-fork
+    VERSION=p3817-trunk-$(date +%Y%m%d)
+    LLVM_ENABLE_RUNTIMES+=";libunwind"
+    ;;
 p3822-trunk)
     BRANCH=users/yuxuanchen1997/p3822r0-requirements-noexcept
     URL=https://github.com/yuxuanchen1997/llvm-project


### PR DESCRIPTION
## Summary
Adds a build config for [P3817R0](https://github.com/regevran/llvm-project-fork/blob/p3817/P3817.md) ("Structured Binding Assignments"), a WG21 proposal that extends structured bindings with a `using` keyword so an element can assign to a pre-existing variable instead of declaring a new one:

```cpp
int id;
auto [using id, name] = get_record();  // id is assigned; name is declared
```

Fork: https://github.com/regevran/llvm-project-fork, branch `p3817`, based on a recent `llvm/llvm-project` main.

## Companion PRs
- compiler-explorer/compiler-workflows#69 (nightly build workflow entry)
- compiler-explorer/infra#2236 (install target)
- compiler-explorer/compiler-explorer#8929 (properties entry)

Following the pattern from the P3334 build config (commit 826e1e93f0dff5d83a9ac98df33b39cfbcfbf718).