### PR TITLE
Adapt clang-rocm builder to use therock tags for 7.14+

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -309,6 +309,10 @@ rocm-*)
             x=${BASH_REMATCH[1]}
             y=${BASH_REMATCH[2]}
             ROCM_VERSION=$(( x * 100 + y ))
+            if (( ROCM_VERSION >= 714 )); then
+                # ROCm 7.14 and newer are based on TheRock
+                TAG=therock-${x}.${y}
+            fi
         fi
     fi
     if (( ROCM_VERSION < 601 )); then


### PR DESCRIPTION
Fixup tag for TheRock-based versions.

Required for https://github.com/compiler-explorer/infra/pull/2235