### PR TITLE
[notadragon-contracts-p3850] Add compiler-rt to clang build

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -278,7 +278,7 @@ notadragon-contracts-p3850)
     BRANCH=contracts-p3850
     URL=https://github.com/notadragon/llvm-project
     VERSION=notadragon-contracts-p3850-$(date +%Y%m%d)
-    LLVM_ENABLE_RUNTIMES+=";libunwind"
+    LLVM_ENABLE_RUNTIMES+=";compiler-rt;libunwind"
     ;;
 p1974-trunk)
     BRANCH=godbolt/propconst


### PR DESCRIPTION
The notadragon-contracts-p3850 build (P3850 C++29 contracts fork) only enabled libcxx/libcxxabi/libunwind, so no compiler-rt was built and -fsanitize=address (and the other sanitizers) failed to link. The fork will shortly integrate the sanitizers with the contract-violation handler (P3100 / P4277 / P4301), so the sanitizer runtimes need to be present.

Add compiler-rt to LLVM_ENABLE_RUNTIMES for this build, matching how the thephd.dev config already does it. This builds all the sanitizer runtimes (asan/ubsan/tsan/msan/lsan) in one shot; the static runtimes land in the auto-discovered resource dir, so no compiler-explorer config change is needed.