### PR TITLE
Add a fork of clang implementing P4324

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -289,6 +289,12 @@ ericwf-contracts-trunk)
     VERSION=ericwf-contracts-trunk-$(date +%Y%m%d)
     LLVM_ENABLE_RUNTIMES+=";libunwind"
     ;;
+cppa-contracts-p4324)
+    BRANCH=p4324
+    URL=https://github.com/cppalliance/clang
+    VERSION=cppa-contracts-p4324-$(date +%Y%m%d)
+    LLVM_ENABLE_RUNTIMES+=";libunwind"
+    ;;
 notadragon-contracts-p3850)
     BRANCH=contracts-p3850
     URL=https://github.com/notadragon/llvm-project


### PR DESCRIPTION
This adds an implementation of 
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4324r0.html to the list of built compilers